### PR TITLE
update Dockerfile and Readme to packer 6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 * Update Dockerfile to point to packer version 6.2
 
-# `0.2.0` (2020-03-25)
+## `0.2.0` (2020-03-25)
 
 * Adds Packer action (#1) ([d80192d](https://github.com/ksatirli/packer-github-actions/commit/d80192d)), closes [#1](https://github.com/ksatirli/packer-github-actions/issues/1)
 * adds GitHub Actions for `code-quality` and `repository-management` ([2a0399e](https://github.com/ksatirli/packer-github-actions/commit/2a0399e))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # `0.3.0` (2020-09-24)
+
 * Update Dockerfile to point to packer version 6.2
 
 # `0.2.0` (2020-03-25)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# `0.3.0` (2020-09-24)
+* Update Dockerfile to point to packer version 6.2
+
 # `0.2.0` (2020-03-25)
 
 * Adds Packer action (#1) ([d80192d](https://github.com/ksatirli/packer-github-actions/commit/d80192d)), closes [#1](https://github.com/ksatirli/packer-github-actions/issues/1)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM hashicorp/packer:light@sha256:5ebe2fff60ee439d251f2bcbbb71efef6918439dfd04415fc1ab5bd5a212c591
+FROM hashicorp/packer:light@sha256:9db70fdca396908e9b2082cc600839fdd76b3ebd2ca48d674cf967b31ebfc81d
 
 COPY "entrypoint.sh" "/entrypoint.sh"
 


### PR DESCRIPTION
I've been using this community action. Thanks for the good stuff. I have need of some of the stuff in the newer version of packer. It has been on the street and stable long enough that this doesn't feel like a bleeding edge ask. 


Thanks!